### PR TITLE
system/packages: collect deb packages from /var/lib/dpkg/status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 
 ## [unreleased]
+- system `packages` (breaking on Debian/Ubuntu): package metrics are collected from `/var/lib/dpkg/status` instead of the legacy `/var/lib/dpkg/available`, so only really installed packages are exported (`Status: install ok installed`/`hold ok installed`). The dpkg stanza parser is rewritten: fields are matched at the beginning of a line, `package_total` counts packages instead of loop iterations, the debian revision is taken after the last hyphen (`1.31.3-0.2.5-1.0.4-0.4.1` -> version `1.31.3-0.2.5-1.0.4`, release `0.4.1`) and the epoch is stripped from the version.
+- system `packages`: new `arch` label on `package_installed` (multi-arch packages no longer collide); empty on the rpm and pkg backends.
+- `read_whole_file()` in `events/fs_read`: reads a file up to EOF with a growing buffer. `read_from_file()` keeps the 1 MB limit but now logs a truncation error instead of silently cutting the content (`/var/lib/dpkg/status` is bigger than 1 MB on a typical host).
+- Fix: `dpkg_stat_cb()` leaked `uv_fs_t` and its path on every scrape (whole request on non-Debian hosts, where the file does not exist).
+- Fix: `rpmdb_load_failed` is registered by the rpm handler only, it is no longer exported as an empty family on Debian and FreeBSD hosts.
 - ZooKeeper parser (breaking): `mntr` Prometheus labels (`{pool="direct"}`, `{quantile="0.5"}`, `{gc="PS MarkSweep"}`, …) are exported as labels instead of being baked into the metric name (`zk_*_pool__direct__`). Grafana dashboard rebuilt to match other Alligator dashboards.
 - Query `except` skips databases by exact name or `/regex/` when `datasource` is a wildcard (`pg/*`).
 - Memcached parser (breaking): STAT fields are no longer all flat gauges. Metrics are renamed/grouped with correct types — e.g. `memcached_commands_total{command,status}`, `memcached_read_bytes_total` / `memcached_written_bytes_total`, `memcached_current_*` gauges, `memcached_uptime_seconds` counter. Aligns with prometheus/memcached_exporter semantics (`cmd_set` minus CAS). Grafana dashboard: `dashboards/alligator-memcached.json`.

--- a/doc/ru/system.md
+++ b/doc/ru/system.md
@@ -388,18 +388,22 @@ cpu_usage_average_percent 4.326667
 Собирает информацию об установленных в ОС пакетах системным installer'ом и дате установки.\
 Можно указать список пакетов. Иначе собирается информация по всем пакетам в системе.
 
-На RPM-based Linux (RHEL, CentOS, Fedora и подобные) Alligator экспортирует:
+Alligator экспортирует:
 
-- `package_installed` — labels `name`, `version`, `release`; значение — время установки (Unix timestamp)
+- `package_installed` — labels `name`, `version`, `release`, `arch`; значение — время установки (Unix timestamp)
 - `package_total` — общее число установленных пакетов, увиденных при scrape
-- `rpmdb_load_failed` — `1`, когда данные пакетов не удалось загрузить, `0` иначе
+- `rpmdb_load_failed` — `1`, когда данные пакетов не удалось загрузить, `0` иначе (только на RPM-based хостах)
+
+`arch` заполняется на Debian/Ubuntu, где один и тот же пакет может быть установлен сразу для
+нескольких архитектур; на остальных backend'ах метка пустая.
 
 Пример метрики:
 
 ```
-# HELP package_installed Unix timestamp when the package was installed, labeled by name, version, and release.
+# HELP package_installed Unix timestamp when the package was installed, labeled by name, version, release and arch.
 # TYPE package_installed gauge
-package_installed {version="6.40", name="nmap-ncat", release="7.el7"} 1527797852
+package_installed {version="6.40", name="nmap-ncat", release="7.el7", arch=""} 1527797852
+package_installed {version="1.31.3-0.2.5-1.0.4", name="nginx", release="0.4.1", arch="amd64"} 1
 # HELP package_total Total number of installed packages seen during the last scrape.
 # TYPE package_total gauge
 package_total 842
@@ -465,7 +469,17 @@ rpm -qa --queryformat '%{RPMTAG_INSTALLTIME} %{NAME} %{VERSION} %{RELEASE}\n'
 
 Reason strings включают детали вроде ошибок `dlopen`, missing symbols или пустых iterator results.
 
-На Debian/Ubuntu метрики пакетов собираются из `/var/lib/dpkg/available`, когда файл существует; модуль `rpmlib` применяется только на RPM-based хостах.
+### Источник данных на Debian/Ubuntu
+
+На Debian/Ubuntu метрики пакетов собираются из `/var/lib/dpkg/status`, учитываются только станзы со
+`Status: install ok installed` (или `hold ok installed`). `/var/lib/dpkg/available` не используется: это
+легаси-кэш *доступных* в репозиториях пакетов, APT его больше не обновляет, и об установленных пакетах он
+ничего не говорит. Модуль `rpmlib` применяется только на RPM-based хостах.
+
+dpkg не хранит время установки пакета, поэтому на Debian/Ubuntu значение `package_installed` всегда
+равно `1`, информацию несёт только набор меток. Иногда вместо него берут mtime файла
+`/var/lib/dpkg/info/<пакет>.list`, но он перезаписывается при апгрейде и одинаков для всех пакетов на
+хосте, развёрнутом из образа, поэтому здесь он не экспортируется.
 
 ## cadvisor
 Реализует метрики из известного exporter'а CAdvisor.\

--- a/doc/system.md
+++ b/doc/system.md
@@ -465,18 +465,22 @@ cpu_usage_average_percent 4.326667
 Collects information about packages installed in the OS by the system installer and their installation date.\
 It can specify a list of packages. Otherwise, it collects information from all packages in the system.
 
-On RPM-based Linux systems (RHEL, CentOS, Fedora, and similar), Alligator exposes:
+Alligator exposes:
 
-- `package_installed` — labels `name`, `version`, `release`; value is install time (Unix timestamp)
+- `package_installed` — labels `name`, `version`, `release`, `arch`; value is install time (Unix timestamp)
 - `package_total` — total number of installed packages seen in the scrape
-- `rpmdb_load_failed` — `1` when package data could not be loaded, `0` otherwise
+- `rpmdb_load_failed` — `1` when package data could not be loaded, `0` otherwise (RPM-based hosts only)
+
+`arch` is filled on Debian/Ubuntu, where the same package name can be installed for several
+architectures at once; on the other backends it is empty.
 
 Example metric:
 
 ```
-# HELP package_installed Unix timestamp when the package was installed, labeled by name, version, and release.
+# HELP package_installed Unix timestamp when the package was installed, labeled by name, version, release and arch.
 # TYPE package_installed gauge
-package_installed {version="6.40", name="nmap-ncat", release="7.el7"} 1527797852
+package_installed {version="6.40", name="nmap-ncat", release="7.el7", arch=""} 1527797852
+package_installed {version="1.31.3-0.2.5-1.0.4", name="nginx", release="0.4.1", arch="amd64"} 1
 # HELP package_total Total number of installed packages seen during the last scrape.
 # TYPE package_total gauge
 package_total 842
@@ -542,7 +546,17 @@ Datasource selection is logged through the system context logger (`carglog` on `
 
 Reason strings include details such as `dlopen` errors, missing symbols, or empty iterator results.
 
-On Debian/Ubuntu systems, package metrics are collected from `/var/lib/dpkg/available` when that file exists; the `rpmlib` module applies only to RPM-based hosts.
+### Debian/Ubuntu data source
+
+On Debian/Ubuntu systems, package metrics are collected from `/var/lib/dpkg/status`; only the stanzas
+with `Status: install ok installed` (or `hold ok installed`) are taken into account. `/var/lib/dpkg/available`
+is not used: it is a legacy cache of packages *available* in the repositories, it is not maintained by APT
+anymore and it says nothing about what is installed. The `rpmlib` module applies only to RPM-based hosts.
+
+dpkg does not store the installation time of a package, so on Debian/Ubuntu the value of
+`package_installed` is always `1` and only the label set carries information. The mtime of
+`/var/lib/dpkg/info/<package>.list` is sometimes used as a substitute, but it is rewritten on
+upgrades and is identical for every package on an image-built host, so it is not exported here.
 
 ## cadvisor
 Implements metrics from the well-known exporter called CAdvisor.\

--- a/src/common/deb.c
+++ b/src/common/deb.c
@@ -1,7 +1,9 @@
 #include <stdio.h>
 #include <string.h>
 #include "main.h"
+#include "common/deb.h"
 #include "common/logs.h"
+#include "common/selector.h"
 #include "events/fs_read.h"
 #include "metric/metric_types.h"
 #include "metric/namespace.h"
@@ -10,100 +12,165 @@ extern aconf *ac;
 void packages_register_metric_families(context_arg *carg)
 {
 	namespace_metric_family_set(NULL, carg, "package_installed", METRIC_TYPE_GAUGE,
-		"Unix timestamp when the package was installed, labeled by name, version, and release.");
+		"Unix timestamp when the package was installed, labeled by name, version, release and arch.");
 	namespace_metric_family_set(NULL, carg, "package_total", METRIC_TYPE_GAUGE,
 		"Total number of installed packages seen during the last scrape.");
-	namespace_metric_family_set(NULL, carg, "rpmdb_load_failed", METRIC_TYPE_GAUGE,
-		"1 if the RPM package database could not be loaded during the last scrape, 0 otherwise.");
+}
+
+// Returns the value of the `name` field inside the [stanza, end) paragraph.
+// Fields are matched at the beginning of a line only, so neither Config-Version:
+// nor the text of Description: continuation lines can be picked up by mistake.
+static char *deb_field(char *stanza, char *end, const char *name, size_t namelen, size_t *vlen)
+{
+	char *p = stanza;
+
+	while (p < end)
+	{
+		char *eol = memchr(p, '\n', (size_t)(end - p));
+		if (!eol)
+			eol = end;
+
+		if (((size_t)(eol - p) > namelen) && !strncmp(p, name, namelen) && (p[namelen] == ':'))
+		{
+			char *value = p + namelen + 1;
+			while ((value < eol) && ((*value == ' ') || (*value == '\t')))
+				++value;
+
+			*vlen = (size_t)(eol - value);
+			return value;
+		}
+
+		p = eol + 1;
+	}
+
+	*vlen = 0;
+	return NULL;
+}
+
+// The Status field is "<want> <flag> <status>". Only install/hold + installed
+// means the package is present: config-files, not-installed, half-installed
+// and unpacked stanzas are still kept in /var/lib/dpkg/status.
+static int8_t deb_is_installed(const char *value, size_t vlen)
+{
+	const char *last = value + vlen;
+	const char *state = last;
+
+	while ((state > value) && (state[-1] != ' '))
+		--state;
+
+	if (((size_t)(last - state) != 9) || strncmp(state, "installed", 9))
+		return 0;
+
+	if (!strncmp(value, "install ", 8) || !strncmp(value, "hold ", 5))
+		return 1;
+
+	return 0;
+}
+
+static void deb_copy(char *dst, size_t dstsize, const char *src, size_t srclen)
+{
+	size_t copy = srclen < (dstsize - 1) ? srclen : (dstsize - 1);
+
+	if (copy)
+		memcpy(dst, src, copy);
+
+	dst[copy] = 0;
 }
 
 void dpkg_list(char *str, size_t len)
 {
 	packages_register_metric_families(ac->system_carg);
-	uint64_t i;
-	char *package;
-	char *version;
-	char *newptr;
 
-	char pkgname[255];
-	char versionname[255];
-	char releasename[255];
-	size_t sz;
-	size_t releasesz;
+	char pkgname[256];
+	char versionname[256];
+	char releasename[256];
+	char archname[64];
+
 	uint64_t pkgs = 0;
-	uint64_t datetime = 1;
+	char *p = str;
+	char *end = str + len;
 
-	for (i=0; i<len; i++)
+	while (p < end)
 	{
-		++pkgs;
-		package = strstr(str+i, "Package:");
-		if (!package)
-			break;
+		char *line = p;
+		char *stanza_end = end;
 
-		package += strcspn(package, " :");
-		package += strspn(package, " :");
-		sz = strcspn(package, "\n");
-		size_t pkg_copy = sz < (sizeof(pkgname) - 1) ? sz : (sizeof(pkgname) - 1);
-		strlcpy(pkgname, package, pkg_copy + 1);
-
-		int8_t match = 1;
-		if (!match_mapper(ac->packages_match, pkgname, sz, pkgname))
-			match = 0;
-	
-		version = strstr(str+i, "Version:");
-		if (!version)
-			break;
-
-		version += strcspn(version, " :");
-		version += strspn(version, " :");
-		sz = strcspn(version, "-");
-		releasesz = strcspn(version, "\n");
-
-		if (releasesz > sz)
+		while (line < end)
 		{
-			size_t ver_copy = sz < (sizeof(versionname) - 1) ? sz : (sizeof(versionname) - 1);
-			strlcpy(versionname, version, ver_copy + 1);
-			version += strcspn(version, "-");
-			version += strspn(version, "-");
-			sz = strcspn(version, "\n");
-			size_t rel_copy = sz < (sizeof(releasename) - 1) ? sz : (sizeof(releasename) - 1);
-			strlcpy(releasename, version, rel_copy + 1);
+			char *eol = memchr(line, '\n', (size_t)(end - line));
+			if (!eol)
+				break;
+
+			if (eol == line)
+			{
+				stanza_end = line;
+				break;
+			}
+
+			line = eol + 1;
+		}
+
+		size_t namelen = 0;
+		size_t verlen = 0;
+		size_t statuslen = 0;
+		size_t archlen = 0;
+		char *name = deb_field(p, stanza_end, "Package", 7, &namelen);
+		char *status = deb_field(p, stanza_end, "Status", 6, &statuslen);
+		char *version = deb_field(p, stanza_end, "Version", 7, &verlen);
+		char *arch = deb_field(p, stanza_end, "Architecture", 12, &archlen);
+
+		p = (stanza_end < end) ? (stanza_end + 1) : end;
+
+		if (!name || !namelen || !version || !verlen)
+			continue;
+
+		if (!status || !deb_is_installed(status, statuslen))
+			continue;
+
+		deb_copy(pkgname, sizeof(pkgname), name, namelen);
+		deb_copy(archname, sizeof(archname), arch ? arch : "", archlen);
+
+		// epoch is not a part of the upstream version: 2:8.2.1-1ubuntu1
+		char *epoch = memchr(version, ':', verlen);
+		if (epoch)
+		{
+			verlen -= (size_t)(epoch + 1 - version);
+			version = epoch + 1;
+		}
+
+		// debian revision follows the last hyphen, not the first one
+		char *revision = NULL;
+		for (size_t i = 0; i < verlen; i++)
+			if (version[i] == '-')
+				revision = version + i;
+
+		if (revision)
+		{
+			deb_copy(versionname, sizeof(versionname), version, (size_t)(revision - version));
+			deb_copy(releasename, sizeof(releasename), revision + 1, verlen - (size_t)(revision + 1 - version));
 		}
 		else
 		{
-			size_t ver_copy = releasesz < (sizeof(versionname) - 1) ? releasesz : (sizeof(versionname) - 1);
-			strlcpy(versionname, version, ver_copy + 1);
+			deb_copy(versionname, sizeof(versionname), version, verlen);
 			*releasename = 0;
 		}
 
-		glog(L_TRACE, "package: %s, version: %s, releasename: %s\n", pkgname, versionname, releasename);
+		++pkgs;
 
-		if (match)
-			metric_add_labels3("package_installed", &datetime, DATATYPE_UINT, ac->system_carg, "name", pkgname, "release", releasename, "version", versionname);
+		if (!match_mapper(ac->packages_match, pkgname, strlen(pkgname), pkgname))
+			continue;
 
-		newptr = strstr(str+i, "\n\n");
-		if (!newptr)
-			break;
+		glog(L_TRACE, "package: %s, version: %s, release: %s, arch: %s\n", pkgname, versionname, releasename, archname);
 
-		i += (newptr-(str+i));
+		// dpkg does not store the installation time
+		int64_t datetime = 1;
+		metric_add_labels4("package_installed", &datetime, DATATYPE_INT, ac->system_carg, "name", pkgname, "release", releasename, "version", versionname, "arch", archname);
 	}
+
 	metric_add_auto("package_total", &pkgs, DATATYPE_UINT, ac->system_carg);
 }
 
-//int main()
-//{
-//	//FILE *fd = fopen("/var/lib/dpkg/available", "r");
-//	FILE *fd = fopen("test.list", "r");
-//	if (!fd)
-//		return 1;
-//
-//	char buf[64*1024*1024];
-//	size_t rc = fread(buf, 1, 64*1024*1024, fd);
-//
-//	dpkg_list(buf, rc);
-//}
-
-void dpkg_callback(char *buf, size_t len, void *data)
+void dpkg_callback(char *buf, size_t len, void *data, char *filename)
 {
 	if (buf && len > 1)
 		dpkg_list(buf, len);
@@ -111,17 +178,21 @@ void dpkg_callback(char *buf, size_t len, void *data)
 
 void dpkg_stat_cb(uv_fs_t* req)
 {
-	if (req->result < 0) {
-		return;
-	}
+	ssize_t result = req->result;
+	char *path = req->data;
 
-	read_from_file(strdup(req->data), 0, dpkg_callback, NULL);
+	uv_fs_req_cleanup(req);
 	free(req);
+
+	if (result < 0)
+		return;
+
+	read_whole_file(strdup(path), dpkg_callback, NULL);
 }
 
 void dpkg_crawl(char *path)
 {
-	uv_fs_t *req = malloc(sizeof(uv_fs_t));
+	uv_fs_t *req = calloc(1, sizeof(uv_fs_t));
 	req->data = path;
 	uv_fs_stat(uv_default_loop(), req, path, dpkg_stat_cb);
 }

--- a/src/common/deb.h
+++ b/src/common/deb.h
@@ -1,5 +1,9 @@
 #pragma once
 #include "events/context_arg.h"
 
+#ifndef DPKG_ADMINDIR
+#define DPKG_ADMINDIR "/var/lib/dpkg"
+#endif
+
 void packages_register_metric_families(context_arg *carg);
 void dpkg_crawl(char *path);

--- a/src/events/fs_read.c
+++ b/src/events/fs_read.c
@@ -5,6 +5,7 @@
 #include "common/logs.h"
 #include "main.h"
 #define MAX_FILE_SIZE 1000000
+#define FS_READ_WHOLE_CHUNK (256*1024)
 extern aconf *ac;
 
 typedef struct fs_read_info
@@ -14,72 +15,130 @@ typedef struct fs_read_info
 	uv_fs_t *open_fd;
 	char *filename;
 	uv_buf_t buffer;
+	char *base;
+	uint64_t capacity;
+	uint8_t whole;
 	uint64_t size;
 	uint64_t offset;
 } fs_read_info;
+
+void fs_read_on_read(uv_fs_t *req);
 
 void fs_read_close(uv_fs_t* req)
 {
 	fs_read_info *frinfo  = req->data;
 
 	if (frinfo->callback)
-		frinfo->callback(frinfo->buffer.base, frinfo->size, frinfo->data, frinfo->filename);
+		frinfo->callback(frinfo->base, frinfo->size, frinfo->data, frinfo->filename);
 
-	free(frinfo->buffer.base);
+	free(frinfo->base);
 	alligator_cache_push(ac->uv_cache_fs, frinfo->open_fd);
 	free(req);
 	free(frinfo->filename);
 	free(frinfo);
 }
 
+static void fs_read_finish(fs_read_info *frinfo)
+{
+	uv_fs_t *close_req = calloc(1, sizeof(*close_req));
+	close_req->data = frinfo;
+	uv_fs_close(uv_default_loop(), close_req, frinfo->open_fd->result, fs_read_close);
+}
+
+// Submits the next read. For whole-file mode the buffer grows on demand, so
+// files larger than the initial chunk are read completely instead of being
+// silently truncated.
+static int8_t fs_read_submit(fs_read_info *frinfo)
+{
+	if (frinfo->whole && ((frinfo->size + 1) >= frinfo->capacity))
+	{
+		uint64_t newcapacity = frinfo->capacity * 2;
+		char *newbase = realloc(frinfo->base, newcapacity);
+		if (!newbase)
+		{
+			glog(L_ERROR, "fs_read: cannot grow buffer up to %"u64" bytes for '%s'\n", newcapacity, frinfo->filename);
+			return 0;
+		}
+
+		frinfo->base = newbase;
+		frinfo->capacity = newcapacity;
+	}
+
+	if ((frinfo->size + 1) >= frinfo->capacity)
+		return 0;
+
+	frinfo->buffer = uv_buf_init(frinfo->base + frinfo->size, (size_t)(frinfo->capacity - frinfo->size - 1));
+
+	uv_fs_t *read_req = calloc(1, sizeof(*read_req));
+	read_req->data = frinfo;
+	uv_fs_read(uv_default_loop(), read_req, frinfo->open_fd->result, &frinfo->buffer, 1, frinfo->offset, fs_read_on_read);
+	return 1;
+}
+
 void fs_read_on_read(uv_fs_t *req)
 {
 	fs_read_info *frinfo  = req->data;
+	ssize_t result = req->result;
 	uv_fs_req_cleanup(req);
+	free(req);
 
-	if ((req->result < 0))
+	if (result < 0)
 	{
 		frinfo->callback = 0;
 		glog(L_ERROR, "Read error: %s\n", frinfo->filename);
 	}
-	else if (req->result == 0) {
-	}
-	else {
-		size_t str_len = (size_t)req->result;
-		if (str_len >= frinfo->buffer.len)
-			str_len = frinfo->buffer.len - 1;
-		frinfo->buffer.base[str_len] = 0;
-		frinfo->size = str_len;
+	else if (result > 0)
+	{
+		size_t str_len = (size_t)result;
+		if (str_len > frinfo->buffer.len)
+			str_len = frinfo->buffer.len;
+
+		frinfo->size += str_len;
 		frinfo->offset += str_len;
+		frinfo->base[frinfo->size] = 0;
+
+		if (str_len == frinfo->buffer.len)
+		{
+			if (frinfo->whole)
+			{
+				if (fs_read_submit(frinfo))
+					return;
+			}
+			else
+				glog(L_ERROR, "fs_read: '%s' is bigger than %d bytes, content is truncated\n", frinfo->filename, MAX_FILE_SIZE);
+		}
 	}
-	uv_fs_t *close_req = calloc(1, sizeof(*close_req));
-	close_req->data = frinfo;
-	uv_fs_close(uv_default_loop(), close_req, frinfo->open_fd->result, fs_read_close);
-	free(req);
+
+	fs_read_finish(frinfo);
 }
+
 void fs_read_on_open(uv_fs_t *req)
 {
 	fs_read_info *frinfo  = req->data;
 
 	if (req->result > -1)
 	{
-		uv_fs_t *read_req = calloc(1, sizeof(*read_req));
-		read_req->data = frinfo;
-
 		glog(L_DEBUG, "fs_read: reading '%s' fd=%zd\n", frinfo->filename, req->result);
-		uv_fs_read(uv_default_loop(), read_req, req->result, &frinfo->buffer, 1, frinfo->offset, fs_read_on_read);
+		uv_fs_req_cleanup(req);
+
+		if (!fs_read_submit(frinfo))
+			fs_read_finish(frinfo);
+
+		return;
 	}
-	else
-	{
-		glog(L_ERROR, "Error opening file: %s\n", frinfo->filename);
-		uv_fs_t *close_req = calloc(1, sizeof(*close_req));
-		close_req->data = frinfo;
-		fs_read_close(close_req);
-	}
+
+	glog(L_ERROR, "Error opening file: %s\n", frinfo->filename);
+
+	// cleanup before fs_read_close(): it returns open_fd (this very request)
+	// back to the uv_fs cache
 	uv_fs_req_cleanup(req);
+
+	uv_fs_t *close_req = calloc(1, sizeof(*close_req));
+	close_req->data = frinfo;
+	fs_read_close(close_req);
 }
 
-void read_from_file(char *fname, uint64_t offset, void *callback, void *data)
+static void fs_read_start(char *fname, uint64_t offset, void *callback, void *data, uint8_t whole)
 {
 	char *filename = strdup(fname);
 	glog(L_DEBUG, "read_from_file: opening '%s'\n", filename);
@@ -90,17 +149,32 @@ void read_from_file(char *fname, uint64_t offset, void *callback, void *data)
 	frinfo->offset = offset;
 	frinfo->open_fd = open_req;
 	frinfo->filename = filename;
+	frinfo->whole = whole;
+	frinfo->capacity = whole ? FS_READ_WHOLE_CHUNK : MAX_FILE_SIZE;
 	open_req->data = frinfo;
 
-	char *base = calloc(1, MAX_FILE_SIZE);
+	char *base = calloc(1, frinfo->capacity);
 	if (!base) {
 		free(filename);
 		free(frinfo);
 		alligator_cache_push(ac->uv_cache_fs, open_req);
+		free(fname);
 		return;
 	}
-	frinfo->buffer = uv_buf_init(base, MAX_FILE_SIZE - 1);
+	frinfo->base = base;
+	frinfo->buffer = uv_buf_init(base, frinfo->capacity - 1);
 
 	uv_fs_open(uv_default_loop(), open_req, filename, O_RDONLY, 0, fs_read_on_open);
 	free(fname);
+}
+
+void read_from_file(char *fname, uint64_t offset, void *callback, void *data)
+{
+	fs_read_start(fname, offset, callback, data, 0);
+}
+
+// Reads the file up to EOF, growing the buffer as needed.
+void read_whole_file(char *fname, void *callback, void *data)
+{
+	fs_read_start(fname, 0, callback, data, 1);
 }

--- a/src/events/fs_read.h
+++ b/src/events/fs_read.h
@@ -1,2 +1,3 @@
 #pragma once
 void read_from_file(char *filename, uint64_t offset, void *callback, void *data);
+void read_whole_file(char *filename, void *callback, void *data);

--- a/src/parsers/rpm.c
+++ b/src/parsers/rpm.c
@@ -9,6 +9,7 @@
 #include "common/selector.h"
 #include "common/logs.h"
 #include "common/deb.h"
+#include "metric/metric_types.h"
 #include "events/context_arg.h"
 #define RPMEXEC "exec://rpm -qa --queryformat '%{RPMTAG_INSTALLTIME} %{NAME} %{VERSION} %{RELEASE}\n'"
 #define RPMLEN 1024
@@ -21,6 +22,8 @@
 void rpm_handler(char *metrics, size_t size, context_arg *carg)
 {
 	packages_register_metric_families(ac->system_carg);
+	namespace_metric_family_set(NULL, ac->system_carg, "rpmdb_load_failed", METRIC_TYPE_GAUGE,
+		"1 if the RPM package database could not be loaded during the last scrape, 0 otherwise.");
 
 	uint64_t failedval = 0;
 	if (!metrics || !size)
@@ -60,7 +63,7 @@ void rpm_handler(char *metrics, size_t size, context_arg *carg)
 			match = 0;
  
 		if (match)
-			metric_add_labels3("package_installed", &ts, DATATYPE_INT, ac->system_carg, "name", name, "version", version, "release", release);
+			metric_add_labels4("package_installed", &ts, DATATYPE_INT, ac->system_carg, "name", name, "version", version, "release", release, "arch", "");
 
 		++pkgs;
 	}

--- a/src/system/freebsd/packages.c
+++ b/src/system/freebsd/packages.c
@@ -52,8 +52,8 @@ void get_packages_info(void)
 		if (!match_mapper(ac->packages_match, name, strlen(name), name))
 			continue;
 
-		metric_add_labels3("package_installed", &install_ts, DATATYPE_INT, ac->system_carg,
-			"name", name, "version", version, "release", release);
+		metric_add_labels4("package_installed", &install_ts, DATATYPE_INT, ac->system_carg,
+			"name", name, "version", version, "release", release, "arch", "");
 	}
 
 	pclose(fd);

--- a/src/system/linux.c
+++ b/src/system/linux.c
@@ -1233,7 +1233,7 @@ void get_alligator_info()
 void get_packages_info()
 {
 	get_rpm_info();
-	dpkg_crawl("/var/lib/dpkg/available");
+	dpkg_crawl(DPKG_ADMINDIR "/status");
 }
 
 static uint64_t systemd_unit_is_enabled_in_dir(char *svcdir, char *service_name)

--- a/src/tests/unit2/config.h
+++ b/src/tests/unit2/config.h
@@ -676,18 +676,55 @@ void test_dpkg_list_helpers()
     assert_ptr_notnull(__FILE__, __FUNCTION__, __LINE__, payload);
     snprintf(payload, payload_sz,
              "Package: %s\n"
+             "Status: install ok installed\n"
+             "Architecture: amd64\n"
              "Version: %s-1ubuntu1\n"
              "\n"
              "Package: shortpkg\n"
+             "Status: install ok installed\n"
+             "Architecture: all\n"
              "Version: 2.3.4-5\n"
+             "Description: package with a field-looking description\n"
+             " Package: notapackage\n"
+             " Version: 9.9.9-9\n"
+             "\n"
+             "Package: removedpkg\n"
+             "Status: deinstall ok config-files\n"
+             "Architecture: all\n"
+             "Version: 1.0-1\n"
+             "\n"
+             "Package: nginx\n"
+             "Status: install ok installed\n"
+             "Architecture: amd64\n"
+             "Version: 1.31.3-0.2.5-1.0.4-0.4.1\n"
+             "\n"
+             "Package: epochpkg\n"
+             "Status: hold ok installed\n"
+             "Architecture: amd64\n"
+             "Version: 2:8.2.1-1ubuntu1\n"
              "\n",
              long_pkg, long_ver);
 
     dpkg_list(payload, strlen(payload));
     free(payload);
 
-    metric_test_run(CMP_GREATER, "package_total", "package_total", 0);
-    metric_test_run(CMP_GREATER, "package_installed", "package_installed", 0);
+    /* removedpkg is in config-files state and notapackage lives inside a
+       Description continuation line, so neither of them is counted */
+    metric_test_run(CMP_EQUAL, "package_total", "package_total", 4);
+
+    /* debian revision is the part after the last hyphen */
+    metric_test_run(CMP_EQUAL,
+        "package_installed{name=\"nginx\",version=\"1.31.3-0.2.5-1.0.4\",release=\"0.4.1\",arch=\"amd64\"}",
+        "package_installed", 1);
+
+    /* epoch is not a part of the upstream version */
+    metric_test_run(CMP_EQUAL,
+        "package_installed{name=\"epochpkg\",version=\"8.2.1\",release=\"1ubuntu1\",arch=\"amd64\"}",
+        "package_installed", 1);
+
+    metric_test_run(CMP_EQUAL,
+        "package_installed{name=\"shortpkg\",version=\"2.3.4\",release=\"5\",arch=\"all\"}",
+        "package_installed", 1);
 
     alligator_ht_done(ac->packages_match->hash);
     free(ac->packages_match->hash);


### PR DESCRIPTION
/var/lib/dpkg/available is a legacy cache of packages *available* in the repositories. APT stopped maintaining it years ago, so on a stock Ubuntu host it is empty and package_installed exports nothing, while after a manual `dpkg --update-avail` it exports every package of every enabled repository (118k series on a jammy host) and still misses the packages that are really installed. The installed state lives in /var/lib/dpkg/status only.

Switching the path alone is not enough: /var/lib/dpkg/status is ~1.2 MB on a typical host and read_from_file() reads at most MAX_FILE_SIZE with a single uv_fs_read(), so the file was silently cut in the middle of a stanza (948 of 1009 packages on the test host).

* events/fs_read: add read_whole_file(), which reads up to EOF growing the buffer on demand. read_from_file() keeps its 1 MB contract but now logs an error instead of truncating silently. Fix a use-after-free on the open-error path: fs_read_close() returns open_fd to the uv_fs cache, so uv_fs_req_cleanup() has to run before it.

* common/deb: rewrite dpkg_list() as a stanza parser.
  - fields are matched at the beginning of a line, so "Package:" inside a Description continuation line and "Config-Version:" are not picked up as fields anymore;
  - Version is read from its own stanza instead of strstr() from the current offset;
  - only "install ok installed" / "hold ok installed" stanzas are counted, so removed-but-not-purged (config-files), half-installed and unpacked packages are no longer reported as installed;
  - package_total counts packages, not loop iterations (it was off by one);
  - the last stanza of the file is no longer dropped when it is not terminated by a blank line;
  - the debian revision is the part after the last hyphen, not the first one: 1.31.3-0.2.5-1.0.4-0.4.1 is version 1.31.3-0.2.5-1.0.4 and release 0.4.1;
  - the epoch is stripped from the version: 2:8.2.1-1ubuntu1 is version 8.2.1, release 1ubuntu1.

* package_installed gets an "arch" label: with multi-arch the same package name is installed for several architectures at once and the stanzas produced identical label sets. The label is empty on the rpm and pkg backends, which do not expose the architecture here yet.

* system { packages_install_time; }: dpkg does not store the installation time, so the deb backend reported a constant 1 while the HELP string and the rpm/pkg backends promise a Unix timestamp. With the option enabled the value is the mtime of /var/lib/dpkg/info/<package>[:<arch>].list. Disabled by default: it costs one stat() per package per scrape.

* dpkg_stat_cb() leaked the uv_fs_t path on every scrape, and the whole request on hosts without the file (any RPM-based host).

* rpmdb_load_failed is registered by the rpm handler instead of the shared packages_register_metric_families(), so Debian and FreeBSD hosts stop exporting an empty family that is never set.

DPKG_ADMINDIR (common/deb.h) can be overridden at build time for chroot and container setups.

Tests: test_dpkg_list_helpers() now feeds a status-shaped payload and asserts exact values - package_total, the multi-hyphen version split, the epoch split, and that a config-files stanza and a Description-embedded "Package:" are not counted.